### PR TITLE
chore(api): atualiza jsonwebtoken para 9.0.3 (corrige CVE)

### DIFF
--- a/api/middlewares/auth.js
+++ b/api/middlewares/auth.js
@@ -18,7 +18,7 @@ module.exports = (req, res, next) => {
         return res.status(401).send({ error: "Token malformatado" });
 
     jwt.verify(token, authConfig.secret, (err, decoded) => {
-        if(err) returnres.status(401).send({ error: "Token Invalido" });
+        if(err) return res.status(401).send({ error: "Token Invalido" });
 
         req.usersId = decoded.id;
         return next();

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -14,7 +14,7 @@
         "ejs": "~2.5.7",
         "express": "^4.21.2",
         "http-errors": "^1.8.1",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.3",
         "mongoose": "^5.13.23",
         "morgan": "^1.10.0",
         "nodemon": "^1.18.10"
@@ -1704,12 +1704,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -1718,11 +1718,11 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/jsonwebtoken/node_modules/ms": {
@@ -1731,10 +1731,22 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -1743,12 +1755,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.2",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
     "ejs": "~2.5.7",
     "express": "^4.21.2",
     "http-errors": "^1.8.1",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.3",
     "mongoose": "^5.13.23",
     "morgan": "^1.10.0",
     "nodemon": "^1.18.10"


### PR DESCRIPTION
## O que muda
- Atualiza `jsonwebtoken` de `8.5.1` → `9.0.3` no `/api`, resolvendo as vulnerabilidades reportadas pelo Dependabot (substitui o PR #71, que estava conflitante).
- O lock file (`api/package-lock.json`) foi regenerado.
- Corrige bug pré-existente em `api/middlewares/auth.js`: `returnres.status(...)` (faltava espaço entre `return` e `res`), que causava `ReferenceError` em runtime quando o token era inválido.

## Compatibilidade
A API usada do jsonwebtoken é compatível com a v9 sem alterações:
- `jwt.sign(params, secret, { expiresIn })` em `controller/users.js`
- `jwt.verify(token, secret, callback)` em `middlewares/auth.js`

`npm audit` confirma: jsonwebtoken sem vulnerabilidades após o bump.

## Contexto
Substitui o PR #71 do Dependabot, fechado por estar conflitante. Os demais 37 PRs antigos do Dependabot também foram fechados, pois já haviam sido resolvidos nos bumps manuais de segurança.

🤖 Generated with [Claude Code](https://claude.com/claude-code)