### PR TITLE
fix(app): corrige fluxo de cadastro que falhava ao criar cliente

### DIFF
--- a/app/lib/screens/cadastro_screen.dart
+++ b/app/lib/screens/cadastro_screen.dart
@@ -44,9 +44,9 @@ class _CadastroScreenState extends State<CadastroScreen> {
           );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Cadastro realizado! Faça login.')),
+        const SnackBar(content: Text('Cadastro realizado! Bem-vindo(a).')),
       );
-      context.pop();
+      context.go('/');
     } on ApiException catch (e) {
       _erro(e.message);
     } catch (_) {

--- a/app/lib/state/auth_state.dart
+++ b/app/lib/state/auth_state.dart
@@ -55,8 +55,13 @@ class AuthState extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Cadastro de cliente: cria usuário e cliente, sequencialmente (com
-  /// await real — diferente do app antigo, que disparava sem aguardar).
+  /// Cadastro de cliente. A rota POST /clientes exige autenticação, então o
+  /// fluxo é: cria o usuário (rota pública) → autentica para obter o token →
+  /// cria o registro de cliente já autenticado. Ao final, o usuário fica
+  /// logado.
+  ///
+  /// Substitui o workaround do app antigo, que logava num usuário de teste
+  /// fixo (usuario@batata.com) só para conseguir o token.
   Future<void> cadastrar({
     required String nome,
     required String cpf,
@@ -69,6 +74,9 @@ class AuthState extends ChangeNotifier {
       email: email,
       senha: senha,
     );
+    // Autentica com as credenciais recém-criadas (define a sessão e o token
+    // usado pelo interceptor na chamada seguinte).
+    await login(email: email, senha: senha);
     await _authService.cadastrarCliente(
       nome: nome,
       cpf: cpf,


### PR DESCRIPTION
## Problema

A rota `POST /clientes` da API exige autenticação (`authMiddleware`), mas o `AuthState.cadastrar` criava o usuário e tentava criar o cliente **sem token**, resultando em **401** — o cliente nunca era criado.

No app antigo (`app_old/`) isso era contornado com um `getToken()` que logava num usuário de teste fixo (`usuario@batata.com` / `123`) só para obter o token.

## Solução

Fluxo de cadastro corrigido, sem credenciais fixas:

1. `POST /users` (rota pública) — cria o usuário
2. `POST /users/auth` — autentica com as credenciais recém-criadas (define a sessão e o token usado pelo interceptor)
3. `POST /clientes` — cria o registro de cliente, já autenticado

Ao final, o usuário fica **logado** e é levado à home (UX melhor que o app antigo, que voltava ao login).

## Validação

- `flutter analyze` → No issues found
- `flutter test` → All tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)