### PR TITLE
fix(api): escopo por dono, proteção de rotas, segredos via env e bug do auth

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,10 @@
+# Configuração da API — copie para .env e ajuste (ou defina no ambiente).
+
+# Segredo de assinatura dos tokens JWT. Use um valor longo e aleatório.
+# Ex.: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+JWT_SECRET=troque-este-segredo-em-producao
+
+# String de conexão do MongoDB.
+#   local:  mongodb://localhost:27017/assistencia-tecnica
+#   docker: mongodb://mongodb:27017/assistencia-tecnica
+MONGO_URL=mongodb://localhost:27017/assistencia-tecnica

--- a/api/app.js
+++ b/api/app.js
@@ -7,6 +7,8 @@ var cookieParser = require("cookie-parser");
 var logger = require("morgan");
 var mongoose = require("mongoose");
 
+var config = require("./config");
+
 // declare routes
 var indexRouter = require("./routes/index");
 var usersRouter = require("./routes/users");
@@ -15,7 +17,7 @@ var funcionarioRoute = require("./routes/funcionarios");
 var servicoRoute = require("./routes/servicos");
 var orcamentoRoute = require("./routes/orcamentos");
 
-mongoose.connect("mongodb://localhost:27017/assistencia-tecnica", {
+mongoose.connect(config.mongoUrl, {
   useNewUrlParser: true
 });
 

--- a/api/config/auth.json
+++ b/api/config/auth.json
@@ -1,3 +1,0 @@
-{
-    "secret": "ef39b7965d1a7b3457b51013f68fbdff"
-}

--- a/api/config/index.js
+++ b/api/config/index.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/**
+ * Configuração da API a partir de variáveis de ambiente.
+ *
+ * Mantém segredos e endpoints fora do código-fonte. Em desenvolvimento há
+ * fallbacks inseguros (mesmo padrão do BFF web em web/src/lib/session.ts);
+ * em produção, defina JWT_SECRET e MONGO_URL no ambiente.
+ *
+ *   JWT_SECRET   segredo de assinatura dos tokens JWT
+ *   MONGO_URL    string de conexão do MongoDB
+ */
+module.exports = {
+  jwtSecret:
+    process.env.JWT_SECRET || "dev-insecure-secret-change-me-in-production",
+  mongoUrl:
+    process.env.MONGO_URL || "mongodb://localhost:27017/assistencia-tecnica",
+};

--- a/api/controller/orcamentos.js
+++ b/api/controller/orcamentos.js
@@ -24,7 +24,10 @@ exports.post = (req, res) => {
   });
 };
 exports.get = (req, res) => {
-  Orcamentos.find({})
+  // Clientes só enxergam os próprios orçamentos; equipe (Funcionario) vê todos.
+  const ehCliente = (req.userTipo || "").toLowerCase() === "cliente";
+  const filtro = ehCliente ? { "cliente.email": req.userEmail } : {};
+  Orcamentos.find(filtro)
     .then(data => {
       res.status(200).send(data);
     })

--- a/api/controller/servicos.js
+++ b/api/controller/servicos.js
@@ -25,7 +25,10 @@ exports.post = (req, res) => {
   });
 };
 exports.get = (req, res) => {
-  Servicos.find({})
+  // Clientes só enxergam os próprios serviços; equipe (Funcionario) vê todos.
+  const ehCliente = (req.userTipo || "").toLowerCase() === "cliente";
+  const filtro = ehCliente ? { "cliente.email": req.userEmail } : {};
+  Servicos.find(filtro)
     .then(data => {
       res.status(200).send(data);
     })

--- a/api/controller/users.js
+++ b/api/controller/users.js
@@ -3,10 +3,10 @@
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const Users = require("./../models/users");
-const authConfig = require('../config/auth.json');
+const config = require('../config');
 
 function generateToken(params = {}){
-  return jwt.sign(params, authConfig.secret, {
+  return jwt.sign(params, config.jwtSecret, {
     expiresIn: 86408,
   });
 }
@@ -42,8 +42,8 @@ exports.autenticacao = async (req, res, next) => {
 
   res.send({
     nome: users.nome,
-    email, 
-    token: generateToken({ id: users.id }),
+    email,
+    token: generateToken({ id: users.id, email: users.email, tipo: users.tipo }),
     tipo: users.tipo,
   });
 };

--- a/api/middlewares/auth.js
+++ b/api/middlewares/auth.js
@@ -1,26 +1,28 @@
 const jwt = require('jsonwebtoken');
-const authConfig = require('../config/auth.json');
+const config = require('../config');
 
 module.exports = (req, res, next) => {
     const authHeader = req.headers.authorization;
 
     if(!authHeader)
-        return res.status(401).send({ error: "Tocken nao autorizado" });
+        return res.status(401).send({ error: "Token nao informado" });
 
     const parts = authHeader.split(' ');
-    
-    if(!parts.length === 2)
+
+    if(parts.length !== 2)
         return res.status(401).send({ error: "Erro de Token" });
 
     const [ scheme, token ] = parts;
-    
+
     if(!/^Bearer$/i.test(scheme))
         return res.status(401).send({ error: "Token malformatado" });
 
-    jwt.verify(token, authConfig.secret, (err, decoded) => {
+    jwt.verify(token, config.jwtSecret, (err, decoded) => {
         if(err) return res.status(401).send({ error: "Token Invalido" });
 
         req.usersId = decoded.id;
+        req.userEmail = decoded.email;
+        req.userTipo = decoded.tipo;
         return next();
-    });   
+    });
 };

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -3,9 +3,14 @@
 const express = require("express");
 const router = express.Router();
 const controller = require("./../controller/users");
+const authMiddleware = require("../middlewares/auth");
 
+// Rotas públicas: criação de conta e autenticação.
 router.post("/", controller.post);
 router.post("/auth", controller.autenticacao);
+
+// Demais operações sobre usuários exigem autenticação.
+router.use(authMiddleware);
 router.get("/", controller.get);
 router.get("/:id", controller.getById);
 router.put("/:id", controller.put);

--- a/app/README.md
+++ b/app/README.md
@@ -62,10 +62,10 @@ flutter run
 flutter test
 ```
 
-## Melhorias pendentes (herdadas do contrato da API)
+## Contrato da API
 
-- A listagem de orçamentos/serviços é filtrada por cliente **no app**
-  (`*Service.doCliente`). O ideal é a API filtrar pelo usuário autenticado —
-  hoje todos os registros trafegam para o dispositivo.
-- A API tem rotas de `/users` sem proteção e o segredo JWT versionado; ver a
-  avaliação da API para o plano de endurecimento.
+- A listagem de orçamentos/serviços é **escopada pelo servidor**: um token de
+  cliente recebe apenas os próprios registros (o app não filtra mais por
+  e-mail localmente). Tokens de equipe (`Funcionario`) recebem tudo.
+- O token JWT carrega `id`, `email` e `tipo`; o segredo e a URI do Mongo da API
+  vêm de variáveis de ambiente (`JWT_SECRET`, `MONGO_URL`).

--- a/app/lib/screens/orcamentos_screen.dart
+++ b/app/lib/screens/orcamentos_screen.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 import '../core/format.dart';
 import '../models/orcamento.dart';
 import '../services/orcamento_service.dart';
-import '../state/auth_state.dart';
 import '../widgets/app_drawer.dart';
 import '../widgets/status_badge.dart';
 
@@ -26,8 +25,8 @@ class _OrcamentosScreenState extends State<OrcamentosScreen> {
   }
 
   Future<List<Orcamento>> _carregar() {
-    final email = context.read<AuthState>().email ?? '';
-    return context.read<OrcamentoService>().doCliente(email);
+    // A API já retorna apenas os orçamentos do cliente autenticado.
+    return context.read<OrcamentoService>().listar();
   }
 
   Future<void> _recarregar() async {

--- a/app/lib/screens/servicos_screen.dart
+++ b/app/lib/screens/servicos_screen.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import '../core/format.dart';
 import '../models/servico.dart';
 import '../services/servico_service.dart';
-import '../state/auth_state.dart';
 import '../widgets/app_drawer.dart';
 import '../widgets/status_badge.dart';
 
@@ -25,8 +24,8 @@ class _ServicosScreenState extends State<ServicosScreen> {
   }
 
   Future<List<Servico>> _carregar() {
-    final email = context.read<AuthState>().email ?? '';
-    return context.read<ServicoService>().doCliente(email);
+    // A API já retorna apenas os serviços do cliente autenticado.
+    return context.read<ServicoService>().listar();
   }
 
   Future<void> _recarregar() async {

--- a/app/lib/services/orcamento_service.dart
+++ b/app/lib/services/orcamento_service.dart
@@ -8,19 +8,12 @@ class OrcamentoService {
 
   /// GET /orcamentos
   ///
-  /// NOTA: a API atual retorna todos os orçamentos; a filtragem por cliente
-  /// é feita no app (ver [doCliente]). O ideal seria a API filtrar pelo
-  /// usuário autenticado — fica como melhoria de contrato.
+  /// A API escopa o resultado pelo usuário autenticado: um cliente recebe
+  /// apenas os próprios orçamentos (o filtro por dono é feito no servidor).
   Future<List<Orcamento>> listar() async {
     final data = await _api.get('/orcamentos');
     final list = (data as List).cast<Map<String, dynamic>>();
     return list.map(Orcamento.fromJson).toList();
-  }
-
-  /// Orçamentos do cliente com o e-mail informado.
-  Future<List<Orcamento>> doCliente(String email) async {
-    final todos = await listar();
-    return todos.where((o) => o.cliente.email == email).toList();
   }
 
   /// PUT /orcamentos/aprovacao/:id

--- a/app/lib/services/servico_service.dart
+++ b/app/lib/services/servico_service.dart
@@ -7,17 +7,14 @@ class ServicoService {
 
   final ApiClient _api;
 
-  /// GET /servicos (filtragem por cliente feita no app — ver nota em
-  /// OrcamentoService.listar).
+  /// GET /servicos
+  ///
+  /// A API escopa o resultado pelo usuário autenticado: um cliente recebe
+  /// apenas os próprios serviços (o filtro por dono é feito no servidor).
   Future<List<Servico>> listar() async {
     final data = await _api.get('/servicos');
     final list = (data as List).cast<Map<String, dynamic>>();
     return list.map(Servico.fromJson).toList();
-  }
-
-  Future<List<Servico>> doCliente(String email) async {
-    final todos = await listar();
-    return todos.where((s) => s.cliente.email == email).toList();
   }
 
   /// POST /servicos — abre um serviço a partir de um orçamento aprovado.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     restart: always
     ports:
       - "3050:3050"
+    environment:
+      # Dentro da rede do compose o Mongo é acessível pelo nome do serviço.
+      - MONGO_URL=mongodb://mongodb:27017/assistencia-tecnica
+      # Defina JWT_SECRET no seu .env (ou ambiente) — não versione segredos.
+      - JWT_SECRET=${JWT_SECRET:-troque-este-segredo-em-producao}
     volumes:
       - ./api:/usr/api
     links:


### PR DESCRIPTION
Corrige quatro gaps de segurança/contrato identificados na avaliação da API. Todas as mudanças foram verificadas de ponta a ponta (Mongo + seed) e não quebram o BFF web (admin continua vendo tudo; área do cliente recebe só o que é dela).

## 1. Escopo por dono (privacidade) 🔐

Antes, `GET /orcamentos` e `GET /servicos` retornavam **todos** os registros e o filtro por cliente era feito no app/web — ou seja, dados de todos os clientes trafegavam para cada dispositivo.

Agora a filtragem é **no servidor**:
- O JWT passa a carregar `id`, `email` e `tipo`.
- O `authMiddleware` expõe `req.userEmail` / `req.userTipo`.
- `GET /orcamentos` e `GET /servicos` filtram por `cliente.email` quando o token é de um **Cliente**; equipe (**Funcionario**) continua vendo tudo.
- O app mobile deixa de filtrar localmente (passa a confiar no escopo do servidor).

## 2. Rotas `/users` protegidas

`GET/PUT/DELETE /users` estavam **públicos**. Agora exigem `authMiddleware`; apenas criação de conta (`POST /`) e login (`POST /auth`) seguem públicos.

## 3. Segredos fora do repositório

- Remove `api/config/auth.json` (segredo JWT versionado).
- `JWT_SECRET` e `MONGO_URL` agora vêm do ambiente via `api/config/index.js` (com fallbacks de dev, mesmo padrão do BFF web).
- `docker-compose` passa as variáveis à API — isso também corrige o host do Mongo no container (antes hardcoded em `localhost`, inalcançável na rede do compose).
- Adiciona `api/.env.example`.

## 4. Bug no middleware de auth

Corrige `if(!parts.length === 2)` → `if(parts.length !== 2)`, que nunca validava o formato do header `Authorization`.

## Verificação (Mongo + seed)

| Cenário | Resultado |
|---|---|
| `GET /users` / `GET /orcamentos` sem token | **401** ✅ |
| Payload do token | `{ id, email, tipo }` ✅ |
| maria (Cliente) → `GET /orcamentos` | 2 registros, só `maria@cliente.com` ✅ |
| admin (Funcionario) → `GET /orcamentos` | 6 registros, todos os clientes ✅ |
| maria (Cliente) → `GET /servicos` | 2 registros, só dela ✅ |
| admin (Funcionario) → `GET /servicos` | 5 registros, todos ✅ |
| Header malformado / esquema errado | **401** ✅ |
| `flutter analyze` + `flutter test` (app) | OK ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)